### PR TITLE
ブログ一覧ページにもバックボタンを追加

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,8 +1,9 @@
 import { getAllPosts, getPostBySlug } from "@/lib/posts";
+import { BackButton } from "@/components/ui/buttons";
+import { notFound } from 'next/navigation';
 import { remark } from "remark";
 import html from "remark-html";
 import Link from "next/link";
-import { notFound } from 'next/navigation';
 
 type Props = {
     params: Promise<{ slug: string }>;
@@ -46,9 +47,7 @@ export default async function PostPage({ params }: Props) {
                     />
 
                     <footer className="border-t border-neutral-800 pt-6 mt-10">
-                        <Link href="/blog" className="mt-6 text-sm font-bold text-green-400 tracking-wide uppercase">
-                            → Back
-                        </Link>
+                        <BackButton link="/blog" />
                     </footer>
                 </article>
             </div>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -47,7 +47,7 @@ export default async function PostPage({ params }: Props) {
                     />
 
                     <footer className="border-t border-neutral-800 pt-6 mt-10">
-                        <BackButton link="/blog" />
+                        <BackButton />
                     </footer>
                 </article>
             </div>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
-import Image from "next/image";
 import { getAllPosts } from "@/lib/posts";
+import { BackButton } from "@/components/ui/buttons";
+import Link from "next/link";
 
 export default async function BlogPage() {
     const posts = getAllPosts();
@@ -8,6 +8,9 @@ export default async function BlogPage() {
     return (
         <div className="text-neutral-100 py-20 px-6">
             <div className="max-w-3xl mx-auto">
+                <div className="flex items-center">
+                    <BackButton />
+                </div>
 
                 <ul className="mt-12 space-y-6">
                     {posts.map((post) => (
@@ -36,6 +39,8 @@ export default async function BlogPage() {
                     ))}
                 </ul>
             </div>
+
+            
         </div>
     );
 }

--- a/src/components/ui/buttons.tsx
+++ b/src/components/ui/buttons.tsx
@@ -27,3 +27,11 @@ export function BookButton({ link, children }: { link: string, children: React.R
         </Link>
     );
 }
+
+export function BackButton({ link }: { link: string }) {
+    return (
+        <Link href={link} className="mt-6 text-sm font-bold text-green-400 tracking-wide uppercase">
+            → Back
+        </Link>
+    );
+}

--- a/src/components/ui/buttons.tsx
+++ b/src/components/ui/buttons.tsx
@@ -47,7 +47,7 @@ export function BackButton({ href, label = "Back" }: { href?: string; label?: st
         <button
             onClick={handleClick}
             aria-label={label}
-            className="inline-flex items-center gap-3 px-3 py-2 bg-neutral-900/80 border border-neutral-800 text-neutral-100 rounded-lg shadow-sm hover:border-green-500/60 hover:text-green-300 hover:-translate-y-0.5 transition transform"
+            className="inline-flex items-center gap-3 px-3 py-2 bg-neutral-900/80 border border-neutral-800 text-neutral-100 rounded-lg shadow-sm hover:border-green-500/60 hover:text-green-300"
         >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
                 <path fillRule="evenodd" d="M9.707 14.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 111.414 1.414L6.414 9H17a1 1 0 110 2H6.414l3.293 3.293a1 1 0 010 1.414z" clipRule="evenodd" />

--- a/src/components/ui/buttons.tsx
+++ b/src/components/ui/buttons.tsx
@@ -1,4 +1,7 @@
+"use client";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import React from "react";
 
 export function GithubButton({ sublink }: { sublink: string }) {
     return (
@@ -15,7 +18,7 @@ export function GithubButton({ sublink }: { sublink: string }) {
     );
 }
 
-export function BookButton({ link, children }: { link: string, children: React.ReactNode }) {
+export function BookButton({ link, children }: { link: string; children: React.ReactNode }) {
     return (
         <Link
             href={link}
@@ -28,10 +31,28 @@ export function BookButton({ link, children }: { link: string, children: React.R
     );
 }
 
-export function BackButton({ link }: { link: string }) {
+export function BackButton({ href, label = "Back" }: { href?: string; label?: string }) {
+    const router = useRouter();
+
+    const handleClick = (e: React.MouseEvent) => {
+        e.preventDefault();
+        if (href) {
+            router.push(href);
+        } else {
+            router.back();
+        }
+    };
+
     return (
-        <Link href={link} className="mt-6 text-sm font-bold text-green-400 tracking-wide uppercase">
-            → Back
-        </Link>
+        <button
+            onClick={handleClick}
+            aria-label={label}
+            className="inline-flex items-center gap-3 px-3 py-2 bg-neutral-900/80 border border-neutral-800 text-neutral-100 rounded-lg shadow-sm hover:border-green-500/60 hover:text-green-300 hover:-translate-y-0.5 transition transform"
+        >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
+                <path fillRule="evenodd" d="M9.707 14.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 111.414 1.414L6.414 9H17a1 1 0 110 2H6.414l3.293 3.293a1 1 0 010 1.414z" clipRule="evenodd" />
+            </svg>
+            <span className="text-sm font-medium">{label}</span>
+        </button>
     );
 }


### PR DESCRIPTION
# ブログ一覧にスタイリッシュな「戻る」ボタンを追加

## 概要
ブログ一覧ページ（`src/app/blog/page.tsx`）の上部に、視認性と操作性を高めるカスタム `BackButton` を追加しました。
ボタンはクライアントコンポーネントとして実装し、前のページに戻る（履歴がなければ Next.js の挙動に従う）か、`href` が指定されている場合はそのパスへ遷移します。

## 変更点（主なファイル）
- `src/components/ui/buttons.tsx`
  - モジュールをクライアントに変更（"use client" を追加）。
  - `BackButton` をリデザインして実装（アイコン、ホバー効果、a11y 属性、`href?: string` と `label?: string` をサポート）。
  - 既存の `GithubButton` / `BookButton` はそのまま利用可能。
- `src/app/blog/page.tsx`
  - ブログ一覧ページの内容（max-width コンテナ）の先頭に `BackButton` を挿入。

## 動作
- デフォルト：クリックでブラウザ履歴に戻る（`router.back()`）。
- オプション：`href` を渡すと `router.push(href)` で指定先に移動。
- アクセシビリティ：`button` 要素を使用し、`aria-label` を設定。キーボード操作にも対応。

## 検証
- TypeScript 型チェック実行済み: `npx tsc --noEmit`（エラーなし）
- 見た目と動作はローカルの dev サーバーで確認してください。

## QA 手順（レビュアー向け）
1. リポジトリを pull して dev サーバーを起動:
   ```powershell
   npm run dev
   # or
   yarn dev
   # or
   pnpm dev
   ```
2. ブラウザで `http://localhost:3000/blog` を開く。
3. ページ上部に「戻る」ボタンが表示されていることを確認。
4. 戻るボタンをクリックして前のページに戻る（履歴がない場合は、`<BackButton href="/" />` 等で遷移を確認）。
5. キーボードでフォーカスして Enter/Space で動作することを確認。

## 注意点 / 影響範囲
- `buttons.tsx` をクライアントコンポーネント化したため、このファイル内のコンポーネントはクライアント側でのみ使用することを想定しています。サーバーコンポーネントから直接使用する場合はラップや確認が必要です。
- 既存の `GithubButton` / `BookButton` に動作の変更はありません。

## 追加提案（任意）
- 戻る先を固定したい箇所では `<BackButton href="/" label="Home" />` のように `href` を渡すことを推奨します。
- デザインの微調整（色・サイズ・配置）があれば指示ください。軽微な調整ならこの PR に追記可能です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブログページにバックボタンを追加しました。ブログ一覧ページと個別の記事ページで便利にナビゲートできます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->